### PR TITLE
chore(backend): migrate to Node.js 24 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
         cache-dependency-path: package-lock.json
 

--- a/.github/workflows/stryker-manual.yml
+++ b/.github/workflows/stryker-manual.yml
@@ -65,7 +65,7 @@ jobs:
       if: steps.check_commits.outputs.should_run == 'true'
       uses: actions/setup-node@v7
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM node:lts-bullseye-slim
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /variaMosAdminService
 COPY ./tsconfig.prod.json ./tsconfig.prod.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Node.js version 18 or greater
+- Node.js version 24 or greater
 - PostgreSQL database
 
 ### Configuration

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 
 // Load the test environment variables before anything else
-dotenv.config({ path: path.join(__dirname, "env/test.env") });
+dotenv.config({ path: path.join(process.cwd(), "env/test.env") });
 
 const config: Config = {
   preset: "ts-jest",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@src": "dist"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "@variamosple/variamos-security": "^0.0.15",
@@ -107,5 +107,12 @@
   "overrides": {
     "uuid": "^11.1.1",
     "qs": "^6.15.2"
+  },
+  "allowScripts": {
+    "bcrypt@6.0.0": true,
+    "cpu-features@0.0.10": true,
+    "protobufjs@7.6.5": true,
+    "ssh2@1.17.0": true,
+    "unrs-resolver@1.12.2": true
   }
 }


### PR DESCRIPTION
## Description
This Pull Request migrates the backend service (`variamos_ms_admin`) to Node.js 24 (LTS). The goal is to modernize our stack, resolve dependency alerts, and ensure aligned environments between local development, CI pipelines, and production Docker containers.
    
### Key Changes
- **Docker Configuration**: Updated the base image in `Dockerfile` from `node:20-alpine` to `node:24-alpine`.
- **GitHub Actions CI**: Upgraded the Node.js version to `24` in `ci.yml` and `stryker-manual.yml`.
- **Engine Requirements**: Updated the `engines` field in `package.json` to require `node >= 24.0.0`.
- **Jest Configuration**: Replaced `__dirname` with `process.cwd()` in `jest.config.ts` to solve the runtime `ReferenceError: __dirname is not defined` caused by Node 24's ESM loader.
- **Documentation**: Updated the prerequisites section in `README.md` to reflect the requirement of Node 24+.
    
## Related Issue / Ticket
N/A
    
## How to Test
1. Load Node 24 in your environment:
    ```bash
    nvm install 24 && nvm use 24

2. Clean existing modules and install dependencies:
    ```bash
    rm -rf node_modules && npm install

3. Run architecture checks and TypeScript compilation:
    ```bash
    npm run typecheck && npm run check-arch

4. Verify the test suite:
    ```bash
    npm run test

