### PR TITLE
fix: exclude test files from production build

### DIFF
--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,5 +4,12 @@
     "sourceMap": false,
     "removeComments": true
   },
-  "exclude": ["spec", "build.ts"]
+  "exclude": [
+    "spec",
+    "build.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "vitest.setup.ts",
+    "vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
Excludes test files (*.test.ts, *.spec.ts) and Vitest configuration files from the production TS build in tsconfig.prod.json. This fixes the Docker build failure caused by missing devDependencies (Vitest) in the production environment.
