### PR TITLE
fix: resolve ESM __dirname reference error and add Docker smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,22 @@ jobs:
       run: |
         npm run build
 
+    - name: Build Docker image for testing
+      run: |
+        docker build -t backend-test .
+
+    - name: Run Docker container smoke test
+      run: |
+        docker run -d --name test-app -p 4000:4000 backend-test
+        sleep 5
+        if [ "$(docker inspect -f '{{.State.Running}}' test-app)" != "true" ]; then
+          echo "Error: Container crashed on startup!"
+          docker logs test-app
+          exit 1
+        fi
+        docker stop test-app
+        docker rm test-app
+
     - name: Run TruffleHog Secret Scan
       uses: trufflesecurity/trufflehog@main
       with:

--- a/src/Infrastructure/Storage/DiskStorageService.ts
+++ b/src/Infrastructure/Storage/DiskStorageService.ts
@@ -1,7 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { IStorageService } from "@src/Domain/Core/Service/IStorageService.js";
 import logger from "jet-logger";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export class DiskStorageService implements IStorageService {
   public async deleteFile(filePath: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,11 @@ import "./DataProviders/Bug/BugAssociations.js";
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import multer from "multer";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Ensure uploads directory exists
 const uploadsDir = path.join(__dirname, "./public/uploads");

--- a/src/pre-start.ts
+++ b/src/pre-start.ts
@@ -6,8 +6,12 @@
 
 // NOTE: DO NOT IMPORT ANY SOURCE CODE HERE
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 import { parse } from "ts-command-line-args";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // **** Types **** //
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,11 @@
  */
 
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 import { RouteError } from "@src/common/classes.js";
 import EnvVars from "@src/common/EnvVars.js";
 import HttpStatusCodes from "@src/common/HttpStatusCodes.js";


### PR DESCRIPTION
## Description
This Pull Request resolves the runtime `__dirname is not defined` ReferenceError caused by the ES Modules migration and adds a Docker container smoke test to the CI pipeline to prevent future startup failures.

### Key Changes
- **ESM `__dirname` Compliance**: Replaced all obsolete CommonJS `__dirname` references with ESM-compliant equivalents (`fileURLToPath(import.meta.url)`) in `src/pre-start.ts`, `src/index.ts`, `src/server.ts`, and `src/Infrastructure/Storage/DiskStorageService.ts`.
- **Docker Smoke Test**: Added Docker image compilation and a container startup verification step (smoke test) in `.github/workflows/ci.yml`. This automatically asserts that the built container boots up and remains running on every Pull Request.