### PR TITLE
feat(config): route 'report a problem' menu option to #report-bug

### DIFF
--- a/src/EntryPoints/ConfigurationRouter.ts
+++ b/src/EntryPoints/ConfigurationRouter.ts
@@ -96,9 +96,9 @@ const MENU: Menu = {
     },
     {
       title: "Report a problem",
-      location: "https://github.com/variamosple/VariaMosLanguages/issues/new",
+      location: "#report-bug",
       accessibleFrom: "/variamos_languages/",
-      target: "newWindow",
+      target: "sameWindow",
       allowedPermissions: [],
     },
     {
@@ -110,9 +110,9 @@ const MENU: Menu = {
     },
     {
       title: "Report a problem",
-      location: "https://github.com/variamosple/VariaMosPLE/issues/new",
+      location: "#report-bug",
       accessibleFrom: "/",
-      target: "newWindow",
+      target: "sameWindow",
       allowedPermissions: [],
     },
     {
@@ -124,9 +124,9 @@ const MENU: Menu = {
     },
     {
       title: "Report a problem",
-      location: "https://github.com/variamosple/VariaMosAdmin/issues/new",
+      location: "#report-bug",
       accessibleFrom: "/variamos_admin/",
-      target: "newWindow",
+      target: "sameWindow",
       allowedPermissions: ["languages::create", "product-lines::create"],
     },
     {


### PR DESCRIPTION
## Description

This Pull Request updates the dynamically served configuration menu to replace external GitHub issue-creation links for "Report a problem" with a local routing target (#report-bug).

This change prepares the menu to trigger the newly integrated global bug reporting modal in the front-end.

### Key Changes

- Configuration Update: Modified MENU.options in ConfigurationRouter.ts to redirect all three "Report a problem" entries to #report-bug with target: "sameWindow" (matching the backend's NavigationTarget type).
- Scope Preservation: Preserved the existing accessibleFrom constraints and permission configurations for each menu entry to match their original scopes.

## How to Test

1. Run npm install to ensure all packages are up to date.
2. Start the development service in watch mode:
```bash
npm run dev
```

3. Query the menu configuration API (e.g., using `curl http://localhost:4000/v1/configurations/menu` or by inspecting the network tab in the frontend).
4. Verify that the three "Report a problem" options in the JSON response contain `location: "#report-bug"` and `target: "sameWindow"`.
5. Run both unit and integration tests by executing:
```bash
npm run test
```
