### PR TITLE
fix(bug-tracker): resolve foreign key violation for guest bug submissions

### DIFF
--- a/src/DataProviders/Bug/BugRepository.ts
+++ b/src/DataProviders/Bug/BugRepository.ts
@@ -639,7 +639,7 @@ export class BugRepositoryImpl implements IBugRepository {
             action: "create",
             comment: logComment,
             bugId: dbBug.id ?? "",
-            operatorId: createdById || "",
+            operatorId: createdById || undefined,
           },
           { transaction: t },
         );

--- a/src/Domain/Bug/UseCase/BugSubmissionUseCase.ts
+++ b/src/Domain/Bug/UseCase/BugSubmissionUseCase.ts
@@ -81,12 +81,16 @@ export class BugSubmissionUseCase {
     }
 
     let reporterEmail = data.reporterEmail;
+    let resolvedCreatedById: string | undefined = data.createdById;
+
     if (data.createdById) {
       const userResponse = await this.userRepository.findSessionUser(
         new RequestModel(request.transactionId, data.createdById),
       );
       if (userResponse.data?.email) {
         reporterEmail = userResponse.data.email;
+      } else {
+        resolvedCreatedById = undefined;
       }
     }
 
@@ -165,11 +169,11 @@ export class BugSubmissionUseCase {
         priority: data.priority,
         category: data.category,
         githubRepo: data.githubRepo,
-        createdById: data.createdById || "",
+        createdById: resolvedCreatedById || "",
         resolvedFile,
         reporterEmail,
         status,
-        logComment: data.createdById
+        logComment: resolvedCreatedById
           ? status === "open"
             ? "Bug submitted directly to GitHub by admin."
             : "Bug submitted locally by user."


### PR DESCRIPTION
## Description
    
This Pull Request fixes a database integrity constraint violation that occurred when guest users attempted to submit bug reports. Since guest users are not stored in the `user` table, referencing their temporary UUID as the creator/operator violated foreign key constraints.
    
### Key Changes
    
- **Guest Detection**: In `BugSubmissionUseCase.ts`, if the creator of the bug is not found in the database (i.e. guest user), `createdById` is resolved to `undefined` before saving.
- **Log Nullability Fix**: In `BugRepository.ts`, updated `BugLogModel.create` to pass `operatorId: createdById || undefined` instead of falling back to an empty string `""`. This inserts a database `NULL` (which is allowed for guests) rather than an invalid empty string.

## How to Test

1. Run the test suite:
    ```bash
    npm run test