### PR TITLE
ci(deploy): inject NOTIFICATION_SERVICE_URL during remote deployment

### DIFF
--- a/.github/workflows/variamos_ms_admin-main-aws-image.yml
+++ b/.github/workflows/variamos_ms_admin-main-aws-image.yml
@@ -44,7 +44,7 @@ jobs:
           script: |
             echo "Injecting GitHub Secrets into environment..."
             # On cible précisément tes variables d'admin pour ne pas toucher au reste
-            sed -i -E '/^(GITHUB_TOKEN|GITHUB_APP_ID|GITHUB_PRIVATE_KEY|GITHUB_MANAGED_REPOS|GOOGLE_CLIENT_ID|GOOGLE_REDIRECT_URI|LOGIN_REDIRECT_URI|HOME_REDIRECT_URI|API_BASE_URL|SMTP_PASSWORD|SMTP_USER|SMTP_HOST|SMTP_PORT|SMTP_FROM|DB_SCHEMA|ADMIN_HOME_URI)=/d' .env.aws.develop
+            sed -i -E '/^(GITHUB_TOKEN|GITHUB_APP_ID|GITHUB_PRIVATE_KEY|GITHUB_MANAGED_REPOS|GOOGLE_CLIENT_ID|GOOGLE_REDIRECT_URI|LOGIN_REDIRECT_URI|HOME_REDIRECT_URI|API_BASE_URL|SMTP_PASSWORD|SMTP_USER|SMTP_HOST|SMTP_PORT|SMTP_FROM|DB_SCHEMA|ADMIN_HOME_URI|NOTIFICATION_SERVICE_URL)=/d' .env.aws.develop
             echo "GITHUB_TOKEN=\"${{ secrets.ISSUES_PAT_TOKEN }}\"" >> .env.aws.develop
             echo "GITHUB_APP_ID=\"${{ vars.ISSUES_BOT_APP_ID }}\"" >> .env.aws.develop
             echo "GITHUB_PRIVATE_KEY=\"${{ secrets.ISSUES_BOT_PRIVATE_KEY }}\"" >> .env.aws.develop
@@ -61,6 +61,7 @@ jobs:
             echo "SMTP_FROM=\"${{ vars.SMTP_FROM }}\"" >> .env.aws.develop
             echo "DB_SCHEMA=\"${{ vars.DB_SCHEMA }}\"" >> .env.aws.develop
             echo "ADMIN_HOME_URI=\"${{ vars.ADMIN_HOME_URI }}\"" >> .env.aws.develop
+            echo "NOTIFICATION_SERVICE_URL=\"${{ vars.NOTIFICATION_SERVICE_URL }}\"" >> .env.aws.develop
 
             echo "Executing command on remote server..."
             docker compose --env-file .env.aws.develop -f docker-compose-aws-develop-nginx.yml pull variamos_ms_admin


### PR DESCRIPTION
## Description
This Pull Request updates the deployment workflow to inject the `NOTIFICATION_SERVICE_URL` variable into the remote `.env.aws.develop` environment file on AWS.

### Key Changes
- Updated `.github/workflows/variamos_ms_admin-main-aws-image.yml` to include `NOTIFICATION_SERVICE_URL` in the environment cleanup regex and append the GitHub variable value during SSH deployment.